### PR TITLE
fix: Enable image viewing in volunteer dashboard using presigned URLs

### DIFF
--- a/src/app/api/volunteer/history/route.ts
+++ b/src/app/api/volunteer/history/route.ts
@@ -5,6 +5,7 @@ import { verifyToken } from "@/lib/auth";
 import { pendingReportsQuerySchema } from "@/lib/validation/volunteerSchemas";
 import { ERROR_CODES } from "@/lib/errorCodes";
 import { ZodError } from "zod";
+import { generateReadPresignedUrl } from "@/lib/s3Client";
 
 export async function GET(req: NextRequest) {
   try {
@@ -45,9 +46,7 @@ export async function GET(req: NextRequest) {
             name: true,
           },
         },
-        images: {
-          take: 1,
-        },
+        images: true, // CHANGED from take: 1
       },
       orderBy: {
         verifiedAt: "desc",
@@ -55,6 +54,20 @@ export async function GET(req: NextRequest) {
       skip,
       take: validatedQuery.limit,
     });
+
+    // ADDED: Generate presigned URLs
+    const reportsWithSignedUrls = await Promise.all(
+      reports.map(async (report) => ({
+        ...report,
+        imageUrl: await generateReadPresignedUrl(report.imageUrl),
+        images: await Promise.all(
+          report.images.map(async (img) => ({
+            ...img,
+            url: await generateReadPresignedUrl(img.url),
+          }))
+        ),
+      }))
+    );
 
     const totalCount = await prisma.report.count({
       where: {
@@ -65,7 +78,7 @@ export async function GET(req: NextRequest) {
 
     return sendSuccess(
       {
-        reports,
+        reports: reportsWithSignedUrls, // CHANGED from reports
         pagination: {
           page: validatedQuery.page,
           limit: validatedQuery.limit,

--- a/src/lib/s3Client.ts
+++ b/src/lib/s3Client.ts
@@ -1,4 +1,8 @@
-import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+import {
+  S3Client,
+  PutObjectCommand,
+  GetObjectCommand,
+} from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 
 const s3Client = new S3Client({
@@ -28,4 +32,26 @@ export async function generatePresignedUrl(
 
 export function getPublicS3Url(filename: string): string {
   return `${process.env.NEXT_PUBLIC_S3_URL}/${filename}`;
+}
+
+export async function generateReadPresignedUrl(
+  imageUrl: string,
+  expiresIn: number = 3600
+): Promise<string> {
+  try {
+    // Extract key from S3 URL
+    const url = new URL(imageUrl);
+    const key = url.pathname.substring(1);
+
+    const command = new GetObjectCommand({
+      Bucket: process.env.AWS_BUCKET_NAME!,
+      Key: key,
+    });
+
+    const signedUrl = await getSignedUrl(s3Client, command, { expiresIn });
+    return signedUrl;
+  } catch (error) {
+    console.error("Error generating read presigned URL:", error);
+    return imageUrl;
+  }
 }


### PR DESCRIPTION
### **User description**
## Problem
Volunteers were unable to view report images in the verify and history pages. Images failed to load with "Failed to load image" errors because the stored S3 URLs pointed to a private bucket that blocked direct browser access.

## Solution
Implemented presigned URL generation for image reading/viewing:
- Added `generateReadPresignedUrl()` function to generate temporary signed URLs for GET requests
- Updated volunteer pending reports API to generate presigned URLs before returning data
- Updated volunteer history API to generate presigned URLs before returning data
- Changed image queries to fetch complete image data instead of limiting to first image

## Changes Made

### Modified Files
1. **`src/lib/s3Client.ts`**
   - Added `GetObjectCommand` import from AWS SDK
   - Added `generateReadPresignedUrl()` function to create temporary signed URLs (valid 1 hour)

2. **`src/app/api/volunteer/reports/pending/route.ts`**
   - Imported `generateReadPresignedUrl` function
   - Changed `images: { take: 1 }` to `images: true`
   - Added presigned URL generation for both `imageUrl` and `images` array
   - Return signed URLs in API response

3. **`src/app/api/volunteer/history/route.ts`**
   - Same changes as pending route
   - Generate presigned URLs for historical reports

## How to Test

### Prerequisites
- Have AWS credentials configured in `.env`
- Have at least one pending report with an image in the database
- Be logged in as a volunteer user

### Test Steps

#### 1. Test Pending Reports (Verify Page)
```bash
# Start the development server
npm run dev

# Navigate to volunteer verify page
http://localhost:3000/dashboard/volunteer/verify
```

**Expected Results:**
- Report images should display correctly
- No "Failed to load image" errors
- Images should be visible in both the list view and modal

**To Verify in Console:**
1. Open browser DevTools (F12) → Console tab
2. Look for logs: `Full API Response:`
3. Check that image URLs contain `X-Amz-Algorithm`, `X-Amz-Credential`, `X-Amz-Signature` query parameters (presigned URL markers)
4. No ` Image failed to load` errors should appear

#### 2. Test History Page
```bash
# Navigate to volunteer history page
http://localhost:3000/dashboard/volunteer/history
```

**Expected Results:**
- Previously verified/rejected report images should display
- Switch between "Verified" and "Rejected" tabs - images load in both
- No image loading errors

**Expected Results:**
- Old presigned URLs expire
- New presigned URLs are generated automatically
- Images continue to load correctly

#### 4. Browser Network Tab Verification
1. Open DevTools → Network tab
2. Filter by "Img" or "Media"
3. Click on an image request

**Expected Results:**
- Status: `200 OK`
- URL contains AWS signature parameters
- Response headers show S3 origin

## Security Considerations
- Presigned URLs expire after 1 hour for security
- S3 bucket remains private - no public access configured
- Each API request generates fresh signed URLs
- URLs are unique per request and cannot be reused indefinitely

## Related Issues
Fixes #43


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Enable image viewing in volunteer dashboard using presigned URLs

- Add `generateReadPresignedUrl()` function for secure S3 image access

- Update pending and history APIs to generate presigned URLs for all images

- Fetch complete image data instead of limiting to first image

- Improve report creation to explicitly create image records in database


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["S3 Private Bucket"] -->|"generateReadPresignedUrl()"| B["Presigned URL<br/>1 hour expiry"]
  B -->|"GET request"| C["Volunteer Dashboard"]
  D["Report Creation"] -->|"Create image record"| E["Database"]
  E -->|"Fetch with images"| F["Pending/History APIs"]
  F -->|"Generate signed URLs"| C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>s3Client.ts</strong><dd><code>Add presigned URL generation for image reading</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/s3Client.ts

<ul><li>Added <code>GetObjectCommand</code> import from AWS SDK<br> <li> Implemented <code>generateReadPresignedUrl()</code> function for generating <br>temporary signed URLs<br> <li> Function extracts S3 key from image URL and creates presigned GET <br>request<br> <li> URLs expire in 1 hour (3600 seconds) for security<br> <li> Includes error handling that falls back to original URL on failure</ul>


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S62-1025-TerraReform-Full-Stack-With-NextjsAnd-AWS-Azure-BinBuddy/pull/44/files#diff-4cabb6e7547c5c2cd5540ca02a8c018397bfaa7906e997de7de9c8b6d9a1b3f4">+27/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>route.ts</strong><dd><code>Improve report creation with explicit image records</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/api/reports/create/route.ts

<ul><li>Explicitly create image record in database after report creation<br> <li> Fetch complete report with all images and reporter details<br> <li> Return full report object instead of minimal report data<br> <li> Improved reliability by separating image record creation from report <br>creation</ul>


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S62-1025-TerraReform-Full-Stack-With-NextjsAnd-AWS-Azure-BinBuddy/pull/44/files#diff-e56eb48744eeb77efdc52b57066abcecdd382f35af16a385b1b2625697a711a4">+26/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>route.ts</strong><dd><code>Generate presigned URLs for pending report images</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/api/volunteer/reports/pending/route.ts

<ul><li>Imported <code>generateReadPresignedUrl</code> function from s3Client<br> <li> Changed image query from <code>take: 1</code> to <code>true</code> to fetch all images<br> <li> Added presigned URL generation for both <code>imageUrl</code> and <code>images</code> array<br> <li> Map over reports to generate signed URLs for each image before <br>returning<br> <li> Return reports with presigned URLs in API response</ul>


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S62-1025-TerraReform-Full-Stack-With-NextjsAnd-AWS-Azure-BinBuddy/pull/44/files#diff-64a952e5cfdc1bcdf4c245fe0595c0a79369f2708945810dd0fccdd43299f9b9">+17/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>route.ts</strong><dd><code>Generate presigned URLs for historical report images</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/api/volunteer/history/route.ts

<ul><li>Imported <code>generateReadPresignedUrl</code> function from s3Client<br> <li> Changed image query from <code>take: 1</code> to <code>true</code> to fetch all images<br> <li> Added presigned URL generation for both <code>imageUrl</code> and <code>images</code> array<br> <li> Map over reports to generate signed URLs for each image before <br>returning<br> <li> Return reports with presigned URLs in API response</ul>


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S62-1025-TerraReform-Full-Stack-With-NextjsAnd-AWS-Azure-BinBuddy/pull/44/files#diff-a870917933450fd267475aafabd9cf588556a2c5638cfe2473aab0227241d5b7">+17/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

